### PR TITLE
test: example of less nesting

### DIFF
--- a/tests/testthat/test-summary.cosinor.R
+++ b/tests/testthat/test-summary.cosinor.R
@@ -12,7 +12,7 @@ test_that("summary print works", {
   testthat::expect_no_error(print_obj)
   testthat::expect_snapshot_output(print(print_obj, digits = 2))
 
-  testthat::expect_true(inherits(print_obj, "cglmmSummary"))
+  testthat::expect_s3_class(print_obj, "cglmmSummary")
 
   # test the dispersion and zeroinflation summaries
   object_2 <- cglmm(

--- a/tests/testthat/test-summary.cosinor.R
+++ b/tests/testthat/test-summary.cosinor.R
@@ -1,39 +1,36 @@
 test_that("summary print works", {
-  withr::with_seed(
-    50,
-    {
-      data(vitamind)
-      object <- cglmm(
-        vit_d ~ amp_acro(time,
-          group = "X",
-          period = 12
-        ),
-        data = vitamind
-      )
-      print_obj <- summary(object)
-      testthat::expect_no_error(print_obj)
-      testthat::expect_snapshot_output(print(print_obj, digits = 2))
+  withr::local_seed(50)
 
-      testthat::expect_true(inherits(print_obj, "cglmmSummary"))
-
-      # test the dispersion and zeroinflation summaries
-      object_2 <- cglmm(
-        vit_d ~ amp_acro(time,
-          group = "X",
-          period = 12
-        ),
-        dispformula = ~ amp_acro(time,
-          group = "X",
-          period = 12
-        ), ziformula = ~ amp_acro(time,
-          group = "X",
-          period = 12
-        ),
-        data = vitamind
-      )
-      print_obj <- summary(object_2)
-      testthat::expect_no_error(print_obj)
-      testthat::expect_snapshot_output(print(print_obj, digits = 2))
-    }
+  object <- cglmm(
+    vit_d ~ amp_acro(time,
+      group = "X",
+      period = 12
+    ),
+    data = vitamind
   )
+  print_obj <- summary(object)
+  testthat::expect_no_error(print_obj)
+  testthat::expect_snapshot_output(print(print_obj, digits = 2))
+
+  testthat::expect_true(inherits(print_obj, "cglmmSummary"))
+
+  # test the dispersion and zeroinflation summaries
+  object_2 <- cglmm(
+    vit_d ~ amp_acro(time,
+      group = "X",
+      period = 12
+    ),
+    dispformula = ~ amp_acro(time,
+      group = "X",
+      period = 12
+    ), ziformula = ~ amp_acro(time,
+      group = "X",
+      period = 12
+    ),
+    data = vitamind
+  )
+  print_obj <- summary(object_2)
+  testthat::expect_no_error(print_obj)
+  testthat::expect_snapshot_output(print(print_obj, digits = 2))
+
 })


### PR DESCRIPTION
- use `withr::local_seed()` rather than `withr::with_seed()` to reduce the indentation/nesting.
- remove `data(vitamind)` as the data will be automatically loaded anyway.